### PR TITLE
Raise ArgumentError on bad args

### DIFF
--- a/lib/terrapin/command_line.rb
+++ b/lib/terrapin/command_line.rb
@@ -49,8 +49,16 @@ module Terrapin
     attr_reader :exit_status, :runner
 
     def initialize(binary, params = "", options = {})
-      @binary            = binary.dup
-      @params            = params.dup
+      @binary = binary.dup
+      if params.nil?
+        raise ArgumentError, "2nd argument to CommandLine.new should be a " \
+          "string representing the command line options"
+      end
+      @params = params.dup
+      if options.nil?
+        raise ArgumentError, "3rd argument to CommandLine.new should be a" \
+          "hash of values that will be interpolated into the command line"
+      end
       @options           = options.dup
       @runner            = @options.delete(:runner) || self.class.runner
       @logger            = @options.delete(:logger) || self.class.logger

--- a/spec/terrapin/command_line_spec.rb
+++ b/spec/terrapin/command_line_spec.rb
@@ -6,6 +6,18 @@ describe Terrapin::CommandLine do
     on_unix! # Assume we're on unix unless otherwise specified.
   end
 
+  describe ".new" do
+    it "raises when given nil params" do
+      expect { Terrapin::CommandLine.new("echo", nil) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "raises when given nil options" do
+      expect { Terrapin::CommandLine.new("echo", "", nil) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
   it "takes a command and parameters and produces a Bash command line" do
     cmd = Terrapin::CommandLine.new("convert", "a.jpg b.png", :swallow_stderr => false)
     cmd.command.should == "convert a.jpg b.png"


### PR DESCRIPTION
`Terrapin::CommandLine.new` had a defualt 2nd and 3rd argument of "" and {},
respectively. But if you explicitly pass in `nil`, then you'll get an error
because `#dup` isn't on `nil`. It's not immediately appareny why you get this
error, so this change makes it so that we tell you.

Fixes https://github.com/thoughtbot/cocaine/issues/98