### PR TITLE
Convert params to a String before working on them

### DIFF
--- a/lib/terrapin/command_line.rb
+++ b/lib/terrapin/command_line.rb
@@ -49,21 +49,20 @@ module Terrapin
     attr_reader :exit_status, :runner
 
     def initialize(binary, params = "", options = {})
-      @binary = binary.dup
-      @params = params.to_s.dup
-
       if options.nil?
         raise ArgumentError, "3rd argument to CommandLine.new should be a" \
           "hash of values that will be interpolated into the command line"
       end
-      @options           = options.dup
 
-      @runner            = @options.delete(:runner) || self.class.runner
-      @logger            = @options.delete(:logger) || self.class.logger
-      @swallow_stderr    = @options.delete(:swallow_stderr)
+      @options = options.dup
+      @binary = binary.dup
+      @params = params.to_s.dup
+      @runner = @options.delete(:runner) || self.class.runner
+      @logger = @options.delete(:logger) || self.class.logger
+      @swallow_stderr = @options.delete(:swallow_stderr)
       @expected_outcodes = @options.delete(:expected_outcodes) || [0]
-      @environment       = @options.delete(:environment) || {}
-      @runner_options    = @options.delete(:runner_options) || {}
+      @environment = @options.delete(:environment) || {}
+      @runner_options = @options.delete(:runner_options) || {}
     end
 
     def command(interpolations = {})

--- a/lib/terrapin/command_line.rb
+++ b/lib/terrapin/command_line.rb
@@ -50,16 +50,14 @@ module Terrapin
 
     def initialize(binary, params = "", options = {})
       @binary = binary.dup
-      if params.nil?
-        raise ArgumentError, "2nd argument to CommandLine.new should be a " \
-          "string representing the command line options"
-      end
-      @params = params.dup
+      @params = params.to_s.dup
+
       if options.nil?
         raise ArgumentError, "3rd argument to CommandLine.new should be a" \
           "hash of values that will be interpolated into the command line"
       end
       @options           = options.dup
+
       @runner            = @options.delete(:runner) || self.class.runner
       @logger            = @options.delete(:logger) || self.class.logger
       @swallow_stderr    = @options.delete(:swallow_stderr)

--- a/spec/terrapin/command_line_spec.rb
+++ b/spec/terrapin/command_line_spec.rb
@@ -7,9 +7,9 @@ describe Terrapin::CommandLine do
   end
 
   describe ".new" do
-    it "raises when given nil params" do
-      expect { Terrapin::CommandLine.new("echo", nil) }
-        .to raise_error(ArgumentError)
+    it "treats nil params as blank" do
+      cmd =  Terrapin::CommandLine.new("echo", nil)
+      expect(cmd.run).to eq("\n")
     end
 
     it "raises when given nil options" do


### PR DESCRIPTION
By converting `params` to a String using `#to_s`, this allows the end
user to pass anything string-like, including Symbols and `nil`.

Also fixes #98.