### PR TITLE
Loosen dependency lock on ClimateControl (allow 1.x)

### DIFF
--- a/lib/terrapin/command_line/runners/backticks_runner.rb
+++ b/lib/terrapin/command_line/runners/backticks_runner.rb
@@ -24,7 +24,6 @@ module Terrapin
       def with_modified_environment(env, &block)
         ClimateControl.modify(env, &block)
       end
-
     end
   end
 end

--- a/lib/terrapin/command_line/runners/process_runner.rb
+++ b/lib/terrapin/command_line/runners/process_runner.rb
@@ -35,7 +35,6 @@ module Terrapin
       rescue Errno::ECHILD
         # In JRuby, waiting on a finished pid raises.
       end
-
     end
   end
 end

--- a/terrapin.gemspec
+++ b/terrapin.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{|f| File.basename(f)}
   s.require_paths = ["lib"]
 
-  s.add_dependency('climate_control', '>= 0.0.3', '< 1.0')
+  s.add_dependency('climate_control', '>= 0.0.3', '< 2.0')
   s.add_development_dependency('rspec')
   s.add_development_dependency('rake')
   s.add_development_dependency('activesupport', ">= 3.0.0", "< 5.0")


### PR DESCRIPTION
ClimateControl's 1.0 release doesn't have any breaking API changes
(the major version bump is a reflection of dropping support for some
older Rubies). This change loosens the dependency lock for
`climate_control` to allow any version in the 1.x series to be used.
This allows Terrapin and kt-Paperclip to coexist with the new
ClimateControl release.

ClimateControl 1.0 release notes:
https://github.com/thoughtbot/climate_control/releases/tag/v1.0.0

cc: @joshuaclayton 