### PR TITLE
Update to unlock climate_control dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - jruby-9.1.17.0
+          - jruby-9.4.1.0
           - "2.7"
           - "3.0"
           - "3.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
 
     runs-on: 'ubuntu-latest'
 

--- a/terrapin.gemspec
+++ b/terrapin.gemspec
@@ -1,26 +1,24 @@
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
-require 'terrapin/version'
+require "terrapin/version"
 
 Gem::Specification.new do |s|
-  s.name              = "terrapin"
-  s.version           = Terrapin::VERSION.dup
-  s.platform          = Gem::Platform::RUBY
-  s.author            = "Jon Yurek"
-  s.email             = "jyurek@thoughtbot.com"
-  s.homepage          = "https://github.com/thoughtbot/terrapin"
-  s.summary           = "Run shell commands safely, even with user-supplied values"
-  s.description       = "Run shell commands safely, even with user-supplied values"
-  s.license           = "MIT"
+  s.name = "terrapin"
+  s.version = Terrapin::VERSION.dup
+  s.platform = Gem::Platform::RUBY
+  s.author = "Jon Yurek"
+  s.email = "jyurek@thoughtbot.com"
+  s.homepage = "https://github.com/thoughtbot/terrapin"
+  s.summary = "Run shell commands safely, even with user-supplied values"
+  s.description = "Run shell commands safely, even with user-supplied values"
+  s.license = "MIT"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{|f| File.basename(f)}
+  s.files = `git ls-files`.split("\n")
+  s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('climate_control', '>= 0.0.3', '< 1.0')
-  s.add_development_dependency('rspec')
-  s.add_development_dependency('rake')
-  s.add_development_dependency('activesupport', ">= 3.0.0", "< 5.0")
-  s.add_development_dependency('pry')
+  s.add_dependency("climate_control")
+  s.add_development_dependency("rspec")
+  s.add_development_dependency("rake")
+  s.add_development_dependency("activesupport")
+  s.add_development_dependency("pry")
 end
-

--- a/terrapin.gemspec
+++ b/terrapin.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency("climate_control")
   s.add_development_dependency("rspec")
   s.add_development_dependency("rake")
-  s.add_development_dependency("activesupport")
+  s.add_development_dependency("activesupport", ">= 3.0.0", "< 5.0")
   s.add_development_dependency("pry")
 end


### PR DESCRIPTION
Why this change is being made:
- Climate control is on version 1.3 and I think it should be ready to support this out of the box. We can find out with our specs probably!
- Not sure we need the active support dependency to be locked either

What were the changes made to support this:
- Setup ruby 3.2 on CI as part of the matrix
- remove `test_files` from the gemspec (these are deprecated)
- Run Standard against the whole of the gemspec
- drop the version requirements