### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Setup project
-        run: bundle install
+          bundler-cache: true
       - name: Run test
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - jruby-9.1.17.0
+          - "jruby-9.1.17.0"
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
+          - "head"
 
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 21 * * 6"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Terrapin [![Build Status](https://secure.travis-ci.org/thoughtbot/terrapin.png?branch=main)](http://travis-ci.org/thoughtbot/terrapin)
+# Terrapin [![Build Status](https://secure.travis-ci.org/thoughtbot/terrapin.svg?branch=main)](http://travis-ci.org/thoughtbot/terrapin)
 
 Run shell commands safely, even with user-supplied values
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Terrapin [![Build Status](https://secure.travis-ci.org/thoughtbot/terrapin.png?branch=master)](http://travis-ci.org/thoughtbot/terrapin)
+# Terrapin [![Build Status](https://secure.travis-ci.org/thoughtbot/terrapin.png?branch=main)](http://travis-ci.org/thoughtbot/terrapin)
 
 Run shell commands safely, even with user-supplied values
 
@@ -218,5 +218,5 @@ The names and logos for thoughtbot are trademarks of thoughtbot, inc.
 
 Copyright 2011-2018 Jon Yurek and thoughtbot, inc. This is free software, and
 may be redistributed under the terms specified in the
-[LICENSE](https://github.com/thoughtbot/terrapin/blob/master/LICENSE)
+[LICENSE](https://github.com/thoughtbot/terrapin/blob/main/LICENSE)
 file.

--- a/terrapin.gemspec
+++ b/terrapin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("climate_control")
+  s.add_dependency("climate_control", "1.2.0")
   s.add_development_dependency("rspec")
   s.add_development_dependency("rake")
   s.add_development_dependency("activesupport", ">= 3.0.0", "< 5.0")


### PR DESCRIPTION
List of changes:

1. Add Ruby 3.2 and head.
2. Use bundler-cache for install and cache gems
3. Run tests by cron at "0 21 * * 6". Each week.
4. Add Dependabot for updating GitHub Actions
5. Update links from `master` to `main`
6. Update travis badge. png->svg.

Note: this repo has `master` and `main` branches. Looks like, travis uses `master` branch and should be updated. Also, `master` has commits that missed in `main`. So, let's merge master in main and remove it (master).