### PR TITLE
Release version 1.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+New for 1.0.1:
+
+* Relax version requirement for `climate_control` dependency
+
 New for 1.0.0:
 
 * Terrapin::CommandLine::PosixRunner was removed. You can replace any usage of this with Terrapin::CommandLine::ProcessRunner, which uses Ruby’s builtin Process.spawn.

--- a/lib/terrapin/version.rb
+++ b/lib/terrapin/version.rb
@@ -1,4 +1,4 @@
 # coding: UTF-8
 module Terrapin
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end


### PR DESCRIPTION
The terrapin 1.0.0 recently pushed (thanks!) to rubygems - https://rubygems.org/gems/terrapin/versions/1.0.0 - is based off the `1.0.0` tag, which tags commit 493ff5b, which is ~4 commits back in current main.

I suspect the intention was to include the climate_control dependency relax in 1.0.0?

This PR just bumps the version and adds a note about the dependency to NEWS.

If merged, you could tag this commit with 1.0.1 and re-build / re-push to rubygems; which should include the dependency relax changes as well as the other stuff already in 1.0.0.