### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -207,16 +207,12 @@ Question? Idea? Problem? Bug? Comment? Concern? Like using question marks?
 Thank you to all [the
 contributors](https://github.com/thoughtbot/terrapin/graphs/contributors)!
 
-![thoughtbot](http://thoughtbot.com/logo.png)
-
-Terrapin is maintained and funded by [thoughtbot,
-inc](http://thoughtbot.com/community)
-
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
 ## License
 
-Copyright 2011-2018 Jon Yurek and thoughtbot, inc. This is free software, and
+Copyright © 2011 Jon Yurek and thoughtbot, inc. This is free software, and
 may be redistributed under the terms specified in the
 [LICENSE](https://github.com/thoughtbot/terrapin/blob/master/LICENSE)
 file.
+
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.