### PR TITLE
Fix ruby 3.4 warnings

### DIFF
--- a/lib/terrapin/command_line/multi_pipe.rb
+++ b/lib/terrapin/command_line/multi_pipe.rb
@@ -39,11 +39,11 @@ module Terrapin
       end
 
       def read_stream(io)
-        result = ""
+        result = []
         while partial_result = io.read(8192)
           result << partial_result
         end
-        result
+        result.join
       end
     end
   end

--- a/terrapin.gemspec
+++ b/terrapin.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake")
   s.add_development_dependency("activesupport", ">= 3.0.0", "< 5.0")
   s.add_development_dependency("pry")
+  s.add_development_dependency("logger")
 end


### PR DESCRIPTION
I came across a deprecation warning caused by terrapin while testing ruby 3.4.0-rc1 in a project it's a dependency in:

    terrapin-1.0.1/lib/terrapin/command_line/multi_pipe.rb:44: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)

I've submitted the simplest change to clear the warning, using an Array and `Array#join` to replace the use of `String#<<`.

I also came across another deprecation warning while running the test suite:

    terrapin/spec/spec_helper.rb:9: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add logger to your Gemfile or gemspec to silence this warning.

So I added `logger` as a development dependency being as it's only used in the test suite.