### PR TITLE
Insert an inspect on the exit status

### DIFF
--- a/lib/terrapin/command_line.rb
+++ b/lib/terrapin/command_line.rb
@@ -89,7 +89,7 @@ module Terrapin
 
       unless @expected_outcodes.include?(@exit_status)
         message = [
-          "Command '#{full_command}' returned #{@exit_status}. Expected #{@expected_outcodes.join(", ")}",
+          "Command '#{full_command}' returned #{@exit_status.inspect}. Expected #{@expected_outcodes.join(", ")}",
           "Here is the command output: STDOUT:\n", command_output,
           "\nSTDERR:\n", command_error_output
         ].join("\n")


### PR DESCRIPTION
This ensures a `nil` exit status can be shown.

The contents of this commit was previously merged into the unreleased `master` branch after we'd already moved to working off `main`.

Fixes #12.